### PR TITLE
Correct mesh_max for 230x230 bed size

### DIFF
--- a/printer-creality-ender3-v3-se-2023.cfg
+++ b/printer-creality-ender3-v3-se-2023.cfg
@@ -126,7 +126,7 @@ z_hop_speed: 10
 speed: 120
 horizontal_move_z: 5
 mesh_min: 30,30         # Need to handle head distance with cr-touch (bl_touch)
-mesh_max: 211,222       # Max probe range
+mesh_max: 207,215.5       # Max probe range
 probe_count: 5,5
 algorithm: bicubic
 


### PR DESCRIPTION
Adjust mesh_max to allow for ABL with a 230x230 bed size